### PR TITLE
Complete Phase 2 strategic navigation milestone

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A browser-based 3D galaxy strategy game built around direct interaction with a l
 
 ## Current milestone
 
-The repository now contains the Phase 1 interactive 3D galaxy foundation plus the shared architecture for the long-term 19-phase strategy game: versioned state, deterministic simulation, diplomacy, economy, fleets, armies, technology, intelligence/events, AI decision foundations, and browser save persistence.
+The repository now contains the Phase 1 interactive 3D galaxy foundation and the Phase 2 navigation/strategic-map milestone. Players can move between galaxy, system, and planet focus; inspect state-driven planet and fleet data; use faction filters; and read territory ownership directly from the map. Shared foundations also exist for simulation, diplomacy, economy, military, technology, events, AI, and browser persistence.
 
 The architecture is deliberately data-driven so the visible galaxy can remain the primary command surface as deeper systems are implemented.
 
@@ -48,6 +48,7 @@ Core modules currently include:
 - `src/core/technology.js` — research tree and prerequisites
 - `src/core/events.js` — dynamic events and intelligence-event hooks
 - `src/core/save.js` — versioned browser save slots
+- `src/navigation/` — strategic navigation state, faction territories, and map labels
 - `docs/ROADMAP.md` — complete 19-phase product roadmap
 
 ## 19-phase roadmap

--- a/docs/PHASE-2.md
+++ b/docs/PHASE-2.md
@@ -1,0 +1,23 @@
+# Phase 2 — Galaxy Navigation & Strategic Map
+
+Phase 2 establishes the galaxy as the primary strategic navigation surface.
+
+## Delivered
+
+- Explicit galaxy/system/planet navigation state.
+- Smooth system and planet camera focus with a galaxy reset action.
+- Click-versus-drag protection for reliable map selection.
+- Persistent CSS2D system and fleet labels.
+- State-driven faction territory indexing, color mapping, and ownership rings.
+- Strategic faction filters for planets, systems, and fleets.
+- Data-backed fleet marker and fleet-intel foundation.
+- Seeded star and orbit placement plus visible planet orbital motion.
+- Responsive strategic toolbar and Escape-key navigation reset.
+
+## Navigation contract
+
+`galaxy` is the strategic galaxy view. `system` is a selected star-system view. `planet` is a selected planet view. Moving upward clears deeper selections so stale state cannot survive a navigation change.
+
+## Remaining Phase 2 expansion
+
+Trade-route rendering and live fleet movement remain tied to the later economy and military simulation phases. The current milestone supplies the rendering and navigation contracts those systems will update.

--- a/docs/PHASE-2.md
+++ b/docs/PHASE-2.md
@@ -1,0 +1,19 @@
+# Phase 2 — Galaxy Navigation & Strategic Map
+
+Phase 2 establishes the galaxy as the primary strategic navigation surface.
+
+## Delivered
+
+- Explicit galaxy/system/planet navigation state.
+- System and planet focus helpers.
+- Faction territory indexing and faction color mapping.
+- Lightweight DOM label helpers suitable for a future CSS2DRenderer layer.
+- Strategic-map styling hooks.
+
+## Navigation contract
+
+`galaxy` is the strategic galaxy view. `system` is a selected star-system view. `planet` is a selected planet view. Moving upward clears deeper selections so stale state cannot survive a navigation change.
+
+## Remaining Phase 2 integration
+
+Connect these contracts to the existing Three.js raycasting/UI layer, add visible system labels and fleet markers, and implement smooth camera transitions without changing simulation or combat rules.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,6 +10,8 @@ Three.js/Vite renderer, starfield, star systems, orbiting planets, data-driven p
 ### Phase 2 — Galaxy Navigation & Strategic Map
 System focus, galaxy/system/planet camera transitions, labels, faction territory overlays, fleet markers, trade routes, strategic filters, and navigation state.
 
+**Status:** Phase 2A navigation and the Phase 2B strategic-map foundation are delivered. Trade-route rendering and simulation-backed fleet movement remain dependent on Phases 5 and 6.
+
 ### Phase 3 — Galaxy Data & World Simulation
 Persistent world state, turn/time progression, population, resources, industry, stability, development, procedural generation, and deterministic simulation ticks.
 
@@ -68,3 +70,7 @@ Authoritative server architecture, shared galaxy state, player empires, diplomac
 ## Release Gate
 
 A 1.0 release requires the single-player simulation to be deterministic enough for saves/replays, a stable tutorial, balanced economy/military/AI loops, performance validation, browser compatibility, error recovery, and a documented save schema. Multiplayer remains a separate server-backed deployment concern and is not treated as complete merely because client interfaces exist.
+
+## Continuous Delivery Gates
+
+Every phase must preserve the production build, automated core tests, keyboard-accessible controls, responsive layout, state/save compatibility, and deterministic gameplay behavior. Persistence, accessibility, performance, and error handling evolve with the game rather than waiting for their later expansion phases.

--- a/index.html
+++ b/index.html
@@ -16,6 +16,16 @@
         <div class="status"><span class="status-dot"></span> LIVE GALAXY</div>
       </header>
 
+      <nav class="strategic-toolbar" aria-label="Strategic map controls">
+        <button id="galaxy-view" type="button">GALAXY VIEW</button>
+        <div class="filter-group" aria-label="Faction filters">
+          <span>FILTER</span>
+          <div id="faction-filters"></div>
+        </div>
+      </nav>
+
+      <div id="navigation-status" class="navigation-status" aria-live="polite">GALAXY VIEW</div>
+
       <aside class="hud-panel planet-panel" aria-live="polite">
         <div class="panel-header">
           <span>PLANETARY INTEL</span>
@@ -28,11 +38,11 @@
 
       <div class="hud-bottom">
         <span id="selection-readout">NO SYSTEM SELECTED</span>
-        <span>DRAG TO ROTATE · SCROLL TO ZOOM · CLICK TO INSPECT</span>
+        <span>DRAG TO ROTATE · SCROLL TO ZOOM · CLICK TO FOCUS · GALAXY VIEW TO RESET</span>
       </div>
 
       <div id="loading" class="loading">INITIALIZING GALAXY...</div>
-      <canvas id="galaxy-canvas"></canvas>
+      <canvas id="galaxy-canvas" tabindex="0" aria-label="Interactive three-dimensional galaxy map"></canvas>
     </div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/src/core/gameState.js
+++ b/src/core/gameState.js
@@ -1,6 +1,21 @@
 export const GAME_STATE_VERSION = 1;
 export const PLAYER_FACTION_ID = 'aurora';
 
+const POPULATION_SCALE = Object.freeze({
+  K: 0.001,
+  M: 1,
+  B: 1000,
+});
+
+export function parsePopulation(value) {
+  if (Number.isFinite(value)) return value;
+  const match = String(value).trim().match(/^([0-9]+(?:\.[0-9]+)?)\s*([KMB])?$/i);
+  if (!match) return 1;
+  const amount = Number.parseFloat(match[1]);
+  const unit = match[2]?.toUpperCase();
+  return Number((amount * (POPULATION_SCALE[unit] ?? 1)).toFixed(3));
+}
+
 export function createGameState(seed = 1337) {
   return {
     version: GAME_STATE_VERSION,
@@ -51,7 +66,7 @@ export function hydrateGalaxyState(state, galaxy) {
         id: planet.id,
         systemId: system.id,
         faction: planet.faction,
-        population: Number.parseFloat(String(planet.population).replace(/[^0-9.]/g, '')) || 1,
+        population: parsePopulation(planet.population),
         industry: planet.industry,
         resources: planet.resources,
         defense: planet.defense,
@@ -62,6 +77,14 @@ export function hydrateGalaxyState(state, galaxy) {
       };
     }
   }
+
+  for (const fleet of galaxy.fleets ?? []) {
+    if (!next.factions[fleet.faction]) {
+      throw new Error(`Unknown fleet faction ID: ${fleet.faction}`);
+    }
+    next.fleets[fleet.id] ??= structuredClone(fleet);
+  }
+
   return next;
 }
 

--- a/src/data/galaxy.json
+++ b/src/data/galaxy.json
@@ -6,6 +6,11 @@
       { "id": "aurora", "name": "Aurora Compact", "color": "#55b6ff" },
       { "id": "vanguard", "name": "Vanguard Directorate", "color": "#ff5f6d" }
     ],
+    "fleets": [
+      { "id": "aurora-watch", "name": "Aurora Watch", "faction": "aurora", "systemId": "solara", "strength": 36, "status": "PATROL" },
+      { "id": "free-rovers", "name": "Free Rovers", "faction": "independent", "systemId": "veyra", "strength": 18, "status": "HOLDING" },
+      { "id": "vanguard-spear", "name": "Vanguard Spear", "faction": "vanguard", "systemId": "draconis", "strength": 48, "status": "READY" }
+    ],
     "systems": [
       {"id":"solara","name":"Solara","position":[-18,3,4],"starColor":"#fff1b0","planets":[{"id":"solara-prime","name":"Solara Prime","orbit":3.2,"size":0.65,"faction":"aurora","population":"8.4M","industry":82,"resources":71,"defense":64,"status":"CONTROLLED"},{"id":"solara-ii","name":"Solara II","orbit":5.1,"size":0.42,"faction":"aurora","population":"2.1M","industry":55,"resources":89,"defense":32,"status":"CONTROLLED"}]},
       {"id":"veyra","name":"Veyra","position":[0,0,0],"starColor":"#b8d8ff","planets":[{"id":"veyra","name":"Veyra","orbit":3.6,"size":0.72,"faction":"independent","population":"4.2M","industry":62,"resources":78,"defense":34,"status":"NEUTRAL"},{"id":"veyra-minor","name":"Veyra Minor","orbit":5.7,"size":0.35,"faction":"independent","population":"820K","industry":28,"resources":66,"defense":18,"status":"NEUTRAL"}]},

--- a/src/main.js
+++ b/src/main.js
@@ -1,14 +1,33 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-import galaxyData from './data/galaxy.json';
-import './styles/main.css';
+import { CSS2DObject, CSS2DRenderer } from 'three/addons/renderers/CSS2DRenderer.js';
 
+import { createGameState, hydrateGalaxyState } from './core/gameState.js';
+import galaxyData from './data/galaxy.json';
+import {
+  createLabel,
+  createStrategicMap,
+  factionColor,
+  setLabelState,
+  systemFaction,
+} from './navigation/index.js';
+import './styles/main.css';
+import './styles/strategic-map.css';
+
+const galaxy = galaxyData.galaxy;
+const gameState = hydrateGalaxyState(createGameState(), galaxy);
+const factions = new Map(galaxy.factions.map((faction) => [faction.id, faction]));
+
+const app = document.querySelector('#app');
 const canvas = document.querySelector('#galaxy-canvas');
 const loading = document.querySelector('#loading');
 const panel = document.querySelector('.planet-panel');
 const content = document.querySelector('#planet-content');
 const selectionReadout = document.querySelector('#selection-readout');
+const navigationStatus = document.querySelector('#navigation-status');
 const closePanel = document.querySelector('#close-panel');
+const galaxyViewButton = document.querySelector('#galaxy-view');
+const factionFilters = document.querySelector('#faction-filters');
 
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x03050a);
@@ -21,27 +40,47 @@ const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
 renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
 renderer.setSize(innerWidth, innerHeight);
 
+const labelRenderer = new CSS2DRenderer();
+labelRenderer.setSize(innerWidth, innerHeight);
+labelRenderer.domElement.className = 'label-layer';
+app.appendChild(labelRenderer.domElement);
+
 const controls = new OrbitControls(camera, renderer.domElement);
 controls.enableDamping = true;
 controls.dampingFactor = 0.06;
-controls.minDistance = 10;
+controls.minDistance = 5;
 controls.maxDistance = 90;
 controls.target.set(0, 0, 0);
+
+const strategicMap = createStrategicMap({ camera, controls, scene });
+controls.addEventListener('start', () => strategicMap.cancelTransition());
 
 scene.add(new THREE.AmbientLight(0x667799, 0.7));
 const keyLight = new THREE.PointLight(0xffffff, 2.4, 80);
 scene.add(keyLight);
 
 const selectable = [];
-const systemGroups = [];
+const systemRecords = new Map();
+const planetVisuals = new Map();
+const fleetMarkers = new Map();
 let selected = null;
+
+function createSeededRandom(seed) {
+  let value = seed >>> 0;
+  return () => {
+    value = (Math.imul(value, 1664525) + 1013904223) >>> 0;
+    return value / 4294967296;
+  };
+}
+
+const random = createSeededRandom(gameState.seed);
 
 function makeStars(count = 1600) {
   const positions = new Float32Array(count * 3);
   for (let i = 0; i < count; i += 1) {
-    const radius = 90 + Math.random() * 150;
-    const theta = Math.random() * Math.PI * 2;
-    const phi = Math.acos(2 * Math.random() - 1);
+    const radius = 90 + random() * 150;
+    const theta = random() * Math.PI * 2;
+    const phi = Math.acos(2 * random() - 1);
     positions[i * 3] = radius * Math.sin(phi) * Math.cos(theta);
     positions[i * 3 + 1] = radius * Math.cos(phi);
     positions[i * 3 + 2] = radius * Math.sin(phi) * Math.sin(theta);
@@ -63,94 +102,305 @@ function createOrbit(radius) {
   return new THREE.LineLoop(geometry, material);
 }
 
-function createPlanet(planet, system, factionColor) {
+function createPlanet(planet, system) {
+  const statePlanet = gameState.planets[planet.id];
   const geometry = new THREE.SphereGeometry(planet.size, 20, 20);
-  const material = new THREE.MeshStandardMaterial({ color: factionColor, roughness: 0.75, metalness: 0.08 });
+  const material = new THREE.MeshStandardMaterial({
+    color: factionColor(statePlanet.faction, galaxy.factions),
+    roughness: 0.75,
+    metalness: 0.08,
+  });
   const mesh = new THREE.Mesh(geometry, material);
-  const angle = Math.random() * Math.PI * 2;
-  mesh.position.set(Math.cos(angle) * planet.orbit, 0, Math.sin(angle) * planet.orbit);
-  mesh.userData = { planet, system, baseColor: factionColor };
+  const orbitAngle = random() * Math.PI * 2;
+  mesh.position.set(Math.cos(orbitAngle) * planet.orbit, 0, Math.sin(orbitAngle) * planet.orbit);
+  mesh.userData = {
+    type: 'planet',
+    planetId: planet.id,
+    systemId: system.id,
+    orbit: planet.orbit,
+    orbitAngle,
+    orbitSpeed: 0.035 / Math.sqrt(planet.orbit),
+  };
   selectable.push(mesh);
   return mesh;
+}
+
+function createTerritoryRing(system) {
+  const owner = systemFaction(system, gameState.planets);
+  const geometry = new THREE.RingGeometry(6.7, 7.15, 64);
+  const material = new THREE.MeshBasicMaterial({
+    color: factionColor(owner, galaxy.factions),
+    transparent: true,
+    opacity: 0.16,
+    side: THREE.DoubleSide,
+    depthWrite: false,
+  });
+  const ring = new THREE.Mesh(geometry, material);
+  ring.rotation.x = Math.PI / 2;
+  ring.position.y = -0.08;
+  return ring;
 }
 
 function createSystem(system) {
   const group = new THREE.Group();
   group.position.fromArray(system.position);
-  group.userData.system = system;
+  group.userData.systemId = system.id;
 
   const star = new THREE.Mesh(
     new THREE.SphereGeometry(1.25, 24, 24),
     new THREE.MeshBasicMaterial({ color: system.starColor })
   );
+  star.userData = { type: 'system', systemId: system.id };
+  selectable.push(star);
   group.add(star);
 
+  const territory = createTerritoryRing(system);
+  group.add(territory);
+
+  const labelElement = createLabel(system.name);
+  const label = new CSS2DObject(labelElement);
+  label.position.set(0, 2.1, 0);
+  group.add(label);
+
   system.planets.forEach((planet) => {
-    const faction = galaxyData.galaxy.factions.find((item) => item.id === planet.faction);
-    group.add(createOrbit(planet.orbit));
-    group.add(createPlanet(planet, system, faction?.color ?? '#ffffff'));
+    const orbit = createOrbit(planet.orbit);
+    const mesh = createPlanet(planet, system);
+    group.add(orbit);
+    group.add(mesh);
+    planetVisuals.set(planet.id, { mesh, orbit, planet, system });
   });
 
-  systemGroups.push(group);
+  systemRecords.set(system.id, { group, labelElement, star, system, territory });
   scene.add(group);
 }
 
-function showPlanet(mesh) {
+function createFleetMarker(fleet, offsetIndex) {
+  const systemRecord = systemRecords.get(fleet.systemId);
+  if (!systemRecord) return;
+  const color = factionColor(fleet.faction, galaxy.factions);
+  const geometry = new THREE.OctahedronGeometry(0.38, 0);
+  const material = new THREE.MeshStandardMaterial({
+    color,
+    emissive: color,
+    emissiveIntensity: 0.25,
+    roughness: 0.45,
+  });
+  const marker = new THREE.Mesh(geometry, material);
+  marker.position.set(-2.1 + offsetIndex * 0.75, 1.35, -1.5);
+  marker.userData = { type: 'fleet', fleetId: fleet.id, systemId: fleet.systemId };
+  selectable.push(marker);
+  systemRecord.group.add(marker);
+
+  const labelElement = createLabel(fleet.name, 'galaxy-label fleet-label');
+  const label = new CSS2DObject(labelElement);
+  label.position.set(0, 0.7, 0);
+  marker.add(label);
+  fleetMarkers.set(fleet.id, { fleet, labelElement, marker });
+}
+
+function formatPopulation(population) {
+  if (population >= 1000) return `${(population / 1000).toFixed(2)}B`;
+  if (population < 1) return `${Math.round(population * 1000)}K`;
+  return `${population.toFixed(2)}M`;
+}
+
+function factionById(factionId) {
+  return factions.get(factionId) ?? { id: 'neutral', name: 'Unknown', color: '#ffffff' };
+}
+
+function showPlanet(planetId) {
+  const visual = planetVisuals.get(planetId);
+  const planet = gameState.planets[planetId];
+  if (!visual || !planet) return;
   if (selected) selected.scale.setScalar(1);
-  selected = mesh;
-  mesh.scale.setScalar(1.45);
-  const { planet, system } = mesh.userData;
-  const faction = galaxyData.galaxy.factions.find((item) => item.id === planet.faction);
-  selectionReadout.textContent = `${system.name.toUpperCase()} · ${planet.name.toUpperCase()}`;
+  selected = visual.mesh;
+  selected.scale.setScalar(1.45);
+  const faction = factionById(planet.faction);
+  selectionReadout.textContent = `${visual.system.name.toUpperCase()} · ${visual.planet.name.toUpperCase()}`;
   content.innerHTML = `
     <div class="planet-title">
-      <span class="planet-mark" style="background:${faction?.color ?? '#fff'}"></span>
-      <div><p class="eyebrow">PLANETARY INTEL</p><h2>${planet.name}</h2></div>
+      <span class="planet-mark" style="background:${faction.color}"></span>
+      <div><p class="eyebrow">PLANETARY INTEL</p><h2>${visual.planet.name}</h2></div>
     </div>
-    <div class="intel-row"><span>Faction</span><strong>${faction?.name ?? 'Unknown'}</strong></div>
-    <div class="intel-row"><span>Population</span><strong>${planet.population}</strong></div>
+    <div class="intel-row"><span>Faction</span><strong>${faction.name}</strong></div>
+    <div class="intel-row"><span>Population</span><strong>${formatPopulation(planet.population)}</strong></div>
     <div class="stat"><span>Industry</span><b>${planet.industry}</b><i><em style="width:${planet.industry}%"></em></i></div>
     <div class="stat"><span>Resources</span><b>${planet.resources}</b><i><em style="width:${planet.resources}%"></em></i></div>
     <div class="stat"><span>Defense</span><b>${planet.defense}</b><i><em style="width:${planet.defense}%"></em></i></div>
-    <div class="status-large">${planet.status}</div>
+    <div class="status-large">${visual.planet.status}</div>
   `;
   panel.classList.add('open');
 }
 
+function showFleet(fleetId) {
+  const fleet = gameState.fleets[fleetId];
+  const system = galaxy.systems.find((item) => item.id === fleet?.systemId);
+  if (!fleet || !system) return;
+  const faction = factionById(fleet.faction);
+  selectionReadout.textContent = `${system.name.toUpperCase()} · ${fleet.name.toUpperCase()}`;
+  content.innerHTML = `
+    <div class="planet-title">
+      <span class="planet-mark" style="background:${faction.color}"></span>
+      <div><p class="eyebrow">FLEET CONTACT</p><h2>${fleet.name}</h2></div>
+    </div>
+    <div class="intel-row"><span>Faction</span><strong>${faction.name}</strong></div>
+    <div class="intel-row"><span>System</span><strong>${system.name}</strong></div>
+    <div class="intel-row"><span>Strength</span><strong>${fleet.strength}</strong></div>
+    <div class="status-large">${fleet.status}</div>
+  `;
+  panel.classList.add('open');
+}
+
+function syncGalaxyVisuals() {
+  const filter = strategicMap.state.factionFilter;
+  for (const [planetId, visual] of planetVisuals) {
+    const planet = gameState.planets[planetId];
+    const matches = filter === 'all' || planet.faction === filter;
+    visual.mesh.material.color.set(factionColor(planet.faction, galaxy.factions));
+    visual.mesh.visible = matches;
+    visual.orbit.visible = matches;
+  }
+
+  for (const { labelElement, system, territory } of systemRecords.values()) {
+    const owner = systemFaction(system, gameState.planets);
+    const matches = filter === 'all' || owner === filter;
+    territory.material.color.set(factionColor(owner, galaxy.factions));
+    territory.material.opacity = matches ? 0.18 : 0.025;
+    setLabelState(labelElement, {
+      selected: strategicMap.state.selectedSystem === system.id,
+      faction: owner,
+    });
+    labelElement.dataset.filtered = String(!matches);
+  }
+
+  for (const { fleet, labelElement, marker } of fleetMarkers.values()) {
+    const matches = filter === 'all' || fleet.faction === filter;
+    marker.visible = matches;
+    labelElement.dataset.filtered = String(!matches);
+  }
+
+  factionFilters.querySelectorAll('button').forEach((button) => {
+    button.setAttribute('aria-pressed', String(button.dataset.faction === filter));
+  });
+}
+
+function renderFilterControls() {
+  const options = [{ id: 'all', name: 'All' }, ...galaxy.factions];
+  for (const option of options) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.dataset.faction = option.id;
+    button.textContent = option.name;
+    button.setAttribute('aria-pressed', String(option.id === 'all'));
+    button.addEventListener('click', () => strategicMap.setFactionFilter(option.id));
+    factionFilters.appendChild(button);
+  }
+}
+
+function returnToGalaxy() {
+  strategicMap.returnToGalaxy();
+  panel.classList.remove('open');
+  if (selected) selected.scale.setScalar(1);
+  selected = null;
+  selectionReadout.textContent = 'NO SYSTEM SELECTED';
+}
+
+strategicMap.subscribe((state) => {
+  navigationStatus.textContent = state.mode === 'galaxy'
+    ? 'GALAXY VIEW'
+    : `${state.mode.toUpperCase()} · ${(state.selectedPlanet ?? state.selectedSystem).toUpperCase()}`;
+  syncGalaxyVisuals();
+});
+
 const raycaster = new THREE.Raycaster();
 const pointer = new THREE.Vector2();
+let pointerStart = null;
+
 renderer.domElement.addEventListener('pointerdown', (event) => {
-  pointer.x = (event.clientX / innerWidth) * 2 - 1;
-  pointer.y = -(event.clientY / innerHeight) * 2 + 1;
+  pointerStart = { id: event.pointerId, x: event.clientX, y: event.clientY };
+});
+
+renderer.domElement.addEventListener('pointerup', (event) => {
+  if (!pointerStart || pointerStart.id !== event.pointerId) return;
+  const travel = Math.hypot(event.clientX - pointerStart.x, event.clientY - pointerStart.y);
+  pointerStart = null;
+  if (travel > 6) return;
+
+  const bounds = renderer.domElement.getBoundingClientRect();
+  pointer.x = ((event.clientX - bounds.left) / bounds.width) * 2 - 1;
+  pointer.y = -((event.clientY - bounds.top) / bounds.height) * 2 + 1;
   raycaster.setFromCamera(pointer, camera);
-  const hit = raycaster.intersectObjects(selectable, false)[0];
-  if (hit) showPlanet(hit.object);
+  const hit = raycaster.intersectObjects(selectable.filter((object) => object.visible), false)[0];
+  if (!hit) return;
+
+  const { type, planetId, systemId, fleetId } = hit.object.userData;
+  if (type === 'planet') {
+    const position = hit.object.getWorldPosition(new THREE.Vector3());
+    showPlanet(planetId);
+    strategicMap.selectPlanet(planetId, systemId, position);
+  } else if (type === 'system') {
+    const record = systemRecords.get(systemId);
+    strategicMap.selectSystem(systemId, record.group.position);
+    panel.classList.remove('open');
+    selectionReadout.textContent = `${record.system.name.toUpperCase()} SYSTEM`;
+  } else if (type === 'fleet') {
+    const record = systemRecords.get(systemId);
+    strategicMap.selectSystem(systemId, record.group.position);
+    showFleet(fleetId);
+  }
+});
+
+renderer.domElement.addEventListener('pointercancel', () => {
+  pointerStart = null;
 });
 
 closePanel.addEventListener('click', () => panel.classList.remove('open'));
+galaxyViewButton.addEventListener('click', returnToGalaxy);
+addEventListener('keydown', (event) => {
+  if (event.key === 'Escape') returnToGalaxy();
+});
 
 function resize() {
   camera.aspect = innerWidth / innerHeight;
   camera.updateProjectionMatrix();
   renderer.setSize(innerWidth, innerHeight);
+  labelRenderer.setSize(innerWidth, innerHeight);
 }
 
 addEventListener('resize', resize);
 makeStars();
-galaxyData.galaxy.systems.forEach(createSystem);
+galaxy.systems.forEach(createSystem);
+Object.values(gameState.fleets).forEach(createFleetMarker);
+renderFilterControls();
+syncGalaxyVisuals();
 loading.classList.add('hidden');
+
+const clock = new THREE.Clock();
+const trackedPosition = new THREE.Vector3();
 
 function animate() {
   requestAnimationFrame(animate);
-  systemGroups.forEach((group) => {
-    group.children.forEach((child) => {
-      if (child.userData?.planet) {
-        child.rotation.y += 0.002;
-      }
-    });
-  });
+  const delta = Math.min(clock.getDelta(), 0.05);
+
+  for (const { mesh } of planetVisuals.values()) {
+    mesh.userData.orbitAngle += mesh.userData.orbitSpeed * delta;
+    mesh.position.set(
+      Math.cos(mesh.userData.orbitAngle) * mesh.userData.orbit,
+      0,
+      Math.sin(mesh.userData.orbitAngle) * mesh.userData.orbit
+    );
+    mesh.rotation.y += 0.35 * delta;
+  }
+
+  if (strategicMap.state.mode === 'planet') {
+    planetVisuals.get(strategicMap.state.selectedPlanet)?.mesh.getWorldPosition(trackedPosition);
+    strategicMap.trackPosition(trackedPosition);
+  }
+
+  strategicMap.update();
   controls.update();
   renderer.render(scene, camera);
+  labelRenderer.render(scene, camera);
 }
 
 animate();

--- a/src/navigation/index.js
+++ b/src/navigation/index.js
@@ -1,0 +1,3 @@
+export { createStrategicMap } from './strategicMap.js';
+export { buildTerritoryIndex, factionColor, systemFaction } from './territories.js';
+export { createLabel, setLabelState } from './labels.js';

--- a/src/navigation/index.js
+++ b/src/navigation/index.js
@@ -1,0 +1,3 @@
+export { createStrategicMap } from './strategicMap.js';
+export { buildTerritoryIndex, factionColor } from './territories.js';
+export { createLabel, setLabelState } from './labels.js';

--- a/src/navigation/labels.js
+++ b/src/navigation/labels.js
@@ -1,0 +1,11 @@
+export function createLabel(text, className = 'galaxy-label') {
+  const element = document.createElement('div');
+  element.className = className;
+  element.textContent = text;
+  return element;
+}
+
+export function setLabelState(element, { selected = false, faction = 'neutral' } = {}) {
+  element.dataset.selected = String(selected);
+  element.dataset.faction = faction;
+}

--- a/src/navigation/strategicMap.js
+++ b/src/navigation/strategicMap.js
@@ -1,0 +1,83 @@
+export function createStrategicMap({ camera, controls, scene }) {
+  const state = {
+    selectedSystem: null,
+    selectedPlanet: null,
+    factionFilter: 'all',
+    mode: 'galaxy',
+  };
+  const listeners = new Set();
+  const initialCameraPosition = camera?.position?.clone?.() ?? null;
+  const initialTarget = controls?.target?.clone?.() ?? null;
+  const desiredCameraPosition = initialCameraPosition?.clone?.() ?? null;
+  const desiredTarget = initialTarget?.clone?.() ?? null;
+  let transitioning = false;
+  const emit = () => listeners.forEach((listener) => listener({ ...state }));
+
+  function setFocus(position, distance = 12, height = 5) {
+    if (!position || !desiredCameraPosition || !desiredTarget) return;
+    desiredTarget.copy(position);
+    desiredCameraPosition.set(position.x + distance, position.y + height, position.z + distance);
+    transitioning = true;
+    if (scene) scene.updateMatrixWorld();
+  }
+
+  return {
+    state,
+    selectSystem(systemId, position) {
+      state.selectedSystem = systemId;
+      state.selectedPlanet = null;
+      state.mode = 'system';
+      setFocus(position, 10, 6);
+      emit();
+    },
+    selectPlanet(planetId, systemId, position) {
+      state.selectedSystem = systemId;
+      state.selectedPlanet = planetId;
+      state.mode = 'planet';
+      setFocus(position, 4.5, 2.5);
+      emit();
+    },
+    returnToGalaxy() {
+      state.selectedSystem = null;
+      state.selectedPlanet = null;
+      state.mode = 'galaxy';
+      if (initialCameraPosition && desiredCameraPosition) desiredCameraPosition.copy(initialCameraPosition);
+      if (initialTarget && desiredTarget) desiredTarget.copy(initialTarget);
+      transitioning = true;
+      emit();
+    },
+    setFactionFilter(factionId = 'all') {
+      state.factionFilter = factionId;
+      emit();
+    },
+    trackPosition(position) {
+      if (!position || !desiredTarget || !desiredCameraPosition || state.mode !== 'planet') return;
+      const x = position.x - desiredTarget.x;
+      const y = position.y - desiredTarget.y;
+      const z = position.z - desiredTarget.z;
+      desiredTarget.copy(position);
+      desiredCameraPosition.set(
+        desiredCameraPosition.x + x,
+        desiredCameraPosition.y + y,
+        desiredCameraPosition.z + z
+      );
+      transitioning = true;
+    },
+    update(smoothing = 0.085) {
+      if (!transitioning || !camera || !controls || !desiredCameraPosition || !desiredTarget) return;
+      camera.position.lerp(desiredCameraPosition, smoothing);
+      controls.target.lerp(desiredTarget, smoothing);
+      if (camera.position.distanceTo(desiredCameraPosition) < 0.02
+        && controls.target.distanceTo(desiredTarget) < 0.02) {
+        transitioning = false;
+      }
+    },
+    cancelTransition() {
+      transitioning = false;
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}

--- a/src/navigation/strategicMap.js
+++ b/src/navigation/strategicMap.js
@@ -1,0 +1,38 @@
+export function createStrategicMap({ camera, controls, scene }) {
+  const state = { selectedSystem: null, selectedPlanet: null, mode: 'galaxy' };
+  const listeners = new Set();
+  const emit = () => listeners.forEach((listener) => listener({ ...state }));
+
+  return {
+    state,
+    selectSystem(systemId) {
+      state.selectedSystem = systemId;
+      state.selectedPlanet = null;
+      state.mode = 'system';
+      emit();
+    },
+    selectPlanet(planetId, systemId) {
+      state.selectedSystem = systemId;
+      state.selectedPlanet = planetId;
+      state.mode = 'planet';
+      emit();
+    },
+    returnToGalaxy() {
+      state.selectedSystem = null;
+      state.selectedPlanet = null;
+      state.mode = 'galaxy';
+      emit();
+    },
+    focusObject(object) {
+      if (!object || !camera) return;
+      const target = object.position.clone();
+      camera.position.set(target.x + 8, target.y + 5, target.z + 8);
+      if (controls?.target) controls.target.copy(target);
+      if (scene) scene.updateMatrixWorld();
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    }
+  };
+}

--- a/src/navigation/territories.js
+++ b/src/navigation/territories.js
@@ -1,0 +1,31 @@
+const FACTION_COLORS = Object.freeze({
+  aurora: '#55b6ff',
+  vanguard: '#ff5f6d',
+  independent: '#8ea2b8',
+  neutral: '#94a3b8',
+});
+
+export function factionColor(faction = 'neutral', factions = []) {
+  return factions.find((item) => item.id === faction)?.color
+    ?? FACTION_COLORS[faction]
+    ?? FACTION_COLORS.neutral;
+}
+
+export function systemFaction(system, planets = {}) {
+  const counts = new Map();
+  for (const planet of system.planets ?? []) {
+    const faction = planets[planet.id]?.faction ?? planet.faction ?? 'neutral';
+    counts.set(faction, (counts.get(faction) ?? 0) + 1);
+  }
+
+  return [...counts.entries()].sort((left, right) => right[1] - left[1])[0]?.[0] ?? 'neutral';
+}
+
+export function buildTerritoryIndex(galaxy, planets = {}) {
+  return (galaxy.systems ?? []).reduce((index, system) => {
+    const faction = systemFaction(system, planets);
+    index[faction] ??= [];
+    index[faction].push(system.id);
+    return index;
+  }, {});
+}

--- a/src/navigation/territories.js
+++ b/src/navigation/territories.js
@@ -1,0 +1,20 @@
+const FACTION_COLORS = {
+  player: 0x4fd1ff,
+  federation: 0x65a30d,
+  dominion: 0xdc2626,
+  independent: 0xf59e0b,
+  neutral: 0x94a3b8
+};
+
+export function factionColor(faction = 'neutral') {
+  return FACTION_COLORS[faction] ?? FACTION_COLORS.neutral;
+}
+
+export function buildTerritoryIndex(galaxy) {
+  return (galaxy.systems ?? []).reduce((index, system) => {
+    const faction = system.faction ?? system.owner ?? 'neutral';
+    index[faction] ??= [];
+    index[faction].push(system.id);
+    return index;
+  }, {});
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -9,6 +9,7 @@
 html, body, #app { width: 100%; height: 100%; margin: 0; overflow: hidden; }
 body { background: #03050a; }
 #galaxy-canvas { position: fixed; inset: 0; width: 100%; height: 100%; display: block; }
+#galaxy-canvas:focus-visible { outline: 2px solid #55b6ff; outline-offset: -3px; }
 
 .hud-top, .hud-bottom, .hud-panel, .loading { position: fixed; z-index: 5; }
 .hud-top { inset: 0 0 auto; display: flex; justify-content: space-between; align-items: flex-start; padding: 24px 28px; pointer-events: none; background: linear-gradient(#03050acc, transparent); }
@@ -43,6 +44,6 @@ body { background: #03050a; }
 @media (max-width: 640px) {
   .hud-top { padding: 18px; }
   .status { display: none; }
-  .hud-panel { top: 84px; right: 12px; width: calc(100vw - 24px); }
+  .hud-panel { top: 188px; right: 12px; width: calc(100vw - 24px); max-height: calc(100vh - 250px); overflow-y: auto; }
   .hud-bottom { flex-direction: column; gap: 6px; padding: 10px 12px; }
 }

--- a/src/styles/strategic-map.css
+++ b/src/styles/strategic-map.css
@@ -1,0 +1,8 @@
+.galaxy-label { pointer-events: none; font: 600 12px/1.2 system-ui, sans-serif; letter-spacing: .08em; text-transform: uppercase; text-shadow: 0 1px 8px #000; opacity: .82; }
+.galaxy-label[data-selected='true'] { opacity: 1; font-size: 14px; }
+.galaxy-label[data-faction='dominion'] { color: #f87171; }
+.galaxy-label[data-faction='federation'] { color: #a3e635; }
+.galaxy-label[data-faction='player'] { color: #67e8f9; }
+.galaxy-label[data-faction='independent'] { color: #fbbf24; }
+.strategic-toolbar { display: flex; gap: .5rem; align-items: center; }
+.strategic-toolbar button { cursor: pointer; }

--- a/src/styles/strategic-map.css
+++ b/src/styles/strategic-map.css
@@ -1,0 +1,24 @@
+.label-layer { position: fixed; inset: 0; z-index: 2; pointer-events: none; }
+.galaxy-label { padding: 3px 6px; border: 1px solid #34415699; background: #03050abb; color: #d9e4f3; font: 700 10px/1.2 system-ui, sans-serif; letter-spacing: .1em; text-transform: uppercase; text-shadow: 0 1px 8px #000; opacity: .78; transition: opacity .2s ease, transform .2s ease; }
+.galaxy-label[data-selected='true'] { opacity: 1; transform: scale(1.12); }
+.galaxy-label[data-filtered='true'] { opacity: .16; }
+.galaxy-label[data-faction='aurora'] { color: #75c5ff; border-color: #55b6ff88; }
+.galaxy-label[data-faction='vanguard'] { color: #ff818c; border-color: #ff5f6d88; }
+.galaxy-label[data-faction='independent'] { color: #b5c3d2; border-color: #8ea2b888; }
+.fleet-label { font-size: 8px; letter-spacing: .08em; }
+
+.strategic-toolbar { position: fixed; z-index: 6; top: 82px; left: 28px; display: flex; gap: 10px; align-items: stretch; pointer-events: auto; }
+.strategic-toolbar button { min-height: 34px; padding: 8px 11px; border: 1px solid #344156; background: #070b13e8; color: #9eb0c8; font: 700 9px/1 system-ui, sans-serif; letter-spacing: .12em; cursor: pointer; }
+.strategic-toolbar button:hover, .strategic-toolbar button[aria-pressed='true'] { border-color: #6c86aa; color: #f3f7fd; background: #152033ee; }
+.filter-group { display: flex; align-items: center; gap: 8px; padding: 0 8px; border: 1px solid #263247; background: #050912d9; }
+.filter-group > span { color: #64748a; font-size: 8px; letter-spacing: .16em; }
+#faction-filters { display: flex; gap: 5px; }
+#faction-filters button { min-height: 26px; padding: 6px 8px; }
+.navigation-status { position: fixed; z-index: 5; top: 130px; left: 28px; padding: 6px 9px; border-left: 2px solid #55b6ff; background: #050912cc; color: #8ea2b8; font-size: 9px; letter-spacing: .12em; pointer-events: none; }
+
+@media (max-width: 720px) {
+  .strategic-toolbar { top: 68px; left: 12px; right: 12px; flex-wrap: wrap; }
+  .filter-group { flex: 1 1 100%; padding: 6px; overflow-x: auto; }
+  #faction-filters { min-width: max-content; }
+  .navigation-status { top: 145px; left: 12px; }
+}

--- a/test/faction-consistency.test.js
+++ b/test/faction-consistency.test.js
@@ -3,7 +3,12 @@ import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
 import { evaluateFaction } from '../src/core/ai.js';
-import { createGameState, hydrateGalaxyState, validateGalaxyFactions } from '../src/core/gameState.js';
+import {
+  createGameState,
+  hydrateGalaxyState,
+  parsePopulation,
+  validateGalaxyFactions,
+} from '../src/core/gameState.js';
 
 const galaxyData = JSON.parse(
   await readFile(new URL('../src/data/galaxy.json', import.meta.url), 'utf8')
@@ -28,6 +33,15 @@ test('hydrated planets can be evaluated by each faction', () => {
     assert.equal(evaluation.factionId, factionId);
     assert.ok(evaluation.ownedPlanets > 0);
   }
+
+  assert.equal(Object.keys(state.fleets).length, galaxy.fleets.length);
+  assert.equal(state.fleets['aurora-watch'].systemId, 'solara');
+});
+
+test('population units normalize to millions', () => {
+  assert.equal(parsePopulation('820K'), 0.82);
+  assert.equal(parsePopulation('8.4M'), 8.4);
+  assert.equal(parsePopulation('1.2B'), 1200);
 });
 
 test('hydration rejects unknown planet faction IDs', () => {

--- a/test/strategic-map.test.js
+++ b/test/strategic-map.test.js
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { Vector3 } from 'three';
+
+import { createStrategicMap } from '../src/navigation/strategicMap.js';
+
+test('strategic map moves cleanly between galaxy, system, and planet modes', () => {
+  const camera = { position: new Vector3(0, 18, 36) };
+  const controls = { target: new Vector3(0, 0, 0) };
+  const scene = { updateMatrixWorld() {} };
+  const map = createStrategicMap({ camera, controls, scene });
+  const snapshots = [];
+  map.subscribe((state) => snapshots.push(state));
+
+  map.selectSystem('solara', new Vector3(-18, 3, 4));
+  assert.equal(map.state.mode, 'system');
+  assert.equal(map.state.selectedSystem, 'solara');
+  assert.equal(map.state.selectedPlanet, null);
+
+  map.selectPlanet('solara-prime', 'solara', new Vector3(-15, 3, 4));
+  assert.equal(map.state.mode, 'planet');
+  assert.equal(map.state.selectedPlanet, 'solara-prime');
+
+  map.setFactionFilter('aurora');
+  assert.equal(map.state.factionFilter, 'aurora');
+  map.update(1);
+  assert.deepEqual(camera.position.toArray(), [-10.5, 5.5, 8.5]);
+
+  map.returnToGalaxy();
+  map.update(1);
+  assert.deepEqual(camera.position.toArray(), [0, 18, 36]);
+  assert.deepEqual(controls.target.toArray(), [0, 0, 0]);
+  assert.equal(map.state.mode, 'galaxy');
+  assert.equal(snapshots.length, 4);
+});

--- a/test/territories.test.js
+++ b/test/territories.test.js
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+import { createGameState, hydrateGalaxyState } from '../src/core/gameState.js';
+import { buildTerritoryIndex, factionColor, systemFaction } from '../src/navigation/territories.js';
+
+const galaxyData = JSON.parse(
+  await readFile(new URL('../src/data/galaxy.json', import.meta.url), 'utf8')
+);
+const galaxy = galaxyData.galaxy;
+
+test('territories derive ownership from hydrated planet state', () => {
+  const state = hydrateGalaxyState(createGameState(), galaxy);
+  const index = buildTerritoryIndex(galaxy, state.planets);
+
+  assert.deepEqual(index.aurora, ['solara']);
+  assert.deepEqual(index.vanguard, ['draconis']);
+  assert.deepEqual(index.independent, ['veyra', 'orionis']);
+  assert.equal(systemFaction(galaxy.systems[0], state.planets), 'aurora');
+});
+
+test('faction colors use galaxy data and preserve a neutral fallback', () => {
+  assert.equal(factionColor('aurora', galaxy.factions), '#55b6ff');
+  assert.equal(factionColor('missing', galaxy.factions), '#94a3b8');
+});


### PR DESCRIPTION
## What changed

- Integrated the existing `phase-2-navigation` contracts into the live Three.js map.
- Added smooth galaxy/system/planet camera navigation and a reset action.
- Added click-versus-drag protection, persistent system labels, faction filters, territory rings, and fleet markers.
- Connected the renderer to hydrated campaign state so ownership, planet intel, and fleets share one source of truth.
- Added seeded visual placement and real planet orbital motion.
- Normalized K/M/B population values and hydrated data-backed starter fleets.
- Updated Phase 2 and master-roadmap status documentation.

## Why

The roadmap review identified that the repository had several disconnected foundations but no integrated strategic-map milestone. This change turns the existing navigation branch into a playable, state-driven Phase 2A/2B foundation.

## Validation

- `node --test`: 7/7 passing
- `vite build`: passed
- JavaScript syntax checks: passed
- Diff whitespace check: passed

The existing Vite bundle-size advisory remains non-blocking and is documented for later performance work.